### PR TITLE
Feature more efficient hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -m {rgba-hashing,rgb-hashing,grayscale-hashing}, --hashing-method {rgba-hashing,rgb-hashing,grayscale-hashing}
-                        specify a hashing method (default: rgba-hashing)
+  -m {rgba-hashing,rgb-hashing,grayscale-hashing,grayscale-hist-hashing}, --hashing-method {rgba-hashing,rgb-hashing,grayscale-hashing,grayscale-hist-hashing}
+                        specify a hashing method (default: grayscale-hist-hashing)
   -a {max-dim,max-adim,avg-dim,avg-adim}, --auto-hash-size {max-dim,max-adim,avg-dim,avg-adim}
                         automatic hash size calculation (default: max-adim)
   -s HASH_SIZE, --hash-size HASH_SIZE
@@ -91,8 +91,8 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -m {rgba-hashing,rgb-hashing,grayscale-hashing}, --hashing-method {rgba-hashing,rgb-hashing,grayscale-hashing}
-                        specify a hashing method (default: rgba-hashing)
+  -m {rgba-hashing,rgb-hashing,grayscale-hashing,grayscale-hist-hashing}, --hashing-method {rgba-hashing,rgb-hashing,grayscale-hashing,grayscale-hist-hashing}
+                        specify a hashing method (default: grayscale-hist-hashing)
   -a {max-dim,max-adim,avg-dim,avg-adim}, --auto-hash-size {max-dim,max-adim,avg-dim,avg-adim}
                         automatic hash size calculation (default: max-adim)
   -s HASH_SIZE, --hash-size HASH_SIZE

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -m {rgba-hashing,rgb-hashing,grayscale-hashing,grayscale-hist-hashing}, --hashing-method {rgba-hashing,rgb-hashing,grayscale-hashing,grayscale-hist-hashing}
+  -m {grayscale-hist-hashing,grayscale-hashing,rgb-hashing,rgba-hashing}, --hashing-method {grayscale-hist-hashing,grayscale-hashing,rgb-hashing,rgba-hashing}
                         specify a hashing method (default: grayscale-hist-hashing)
   -a {max-dim,max-adim,avg-dim,avg-adim}, --auto-hash-size {max-dim,max-adim,avg-dim,avg-adim}
                         automatic hash size calculation (default: max-adim)
@@ -91,7 +91,7 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -m {rgba-hashing,rgb-hashing,grayscale-hashing,grayscale-hist-hashing}, --hashing-method {rgba-hashing,rgb-hashing,grayscale-hashing,grayscale-hist-hashing}
+  -m {grayscale-hist-hashing,grayscale-hashing,rgb-hashing,rgba-hashing}, --hashing-method {grayscale-hist-hashing,grayscale-hashing,rgb-hashing,rgba-hashing}
                         specify a hashing method (default: grayscale-hist-hashing)
   -a {max-dim,max-adim,avg-dim,avg-adim}, --auto-hash-size {max-dim,max-adim,avg-dim,avg-adim}
                         automatic hash size calculation (default: max-adim)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ tqdm
 termcolor
 imagehash
 pillow
+numpy
 beautifulsoup4
 requests
 pyinstaller

--- a/src/imdupes/imdupes.py
+++ b/src/imdupes/imdupes.py
@@ -102,8 +102,8 @@ if __name__ == '__main__':
 
         ap_common_args = argparse.ArgumentParser(add_help=False)
         ap_common_args.add_argument(
-            '-m', '--hashing-method', choices=[m.value for m in HashingMethod], default=HashingMethod.RGBA.value,
-            help=f'specify a hashing method (default: {HashingMethod.RGBA.value})'
+            '-m', '--hashing-method', choices=[m.value for m in HashingMethod], default=HashingMethod.BW_HIST.value,
+            help=f'specify a hashing method (default: {HashingMethod.BW_HIST.value})'
         )
         ap_common_args_hash_size = ap_common_args.add_mutually_exclusive_group()
         ap_common_args_hash_size.add_argument(

--- a/src/imdupes/utils/globs.py
+++ b/src/imdupes/utils/globs.py
@@ -64,6 +64,7 @@ class HashingMethod(Enum):
     RGBA = 'rgba-hashing'
     RGB = 'rgb-hashing'
     BW = 'grayscale-hashing'
+    BW_HIST = 'grayscale-hist-hashing'
 
 
 class AutoHashSize(Enum):

--- a/src/imdupes/utils/globs.py
+++ b/src/imdupes/utils/globs.py
@@ -61,10 +61,10 @@ INTERACTIVE_OPTS = {
 
 
 class HashingMethod(Enum):
-    RGBA = 'rgba-hashing'
-    RGB = 'rgb-hashing'
-    BW = 'grayscale-hashing'
     BW_HIST = 'grayscale-hist-hashing'
+    BW = 'grayscale-hashing'
+    RGB = 'rgb-hashing'
+    RGBA = 'rgba-hashing'
 
 
 class AutoHashSize(Enum):

--- a/src/imdupes/utils/imutils.py
+++ b/src/imdupes/utils/imutils.py
@@ -36,4 +36,4 @@ def hash_image(
         return hash_value
 
     if method == HashingMethod.BW:
-        return imagehash.phash(image, hash_size=hash_size).__str__()
+        return imagehash.average_hash(image, hash_size=hash_size).__str__()

--- a/src/imdupes/utils/imutils.py
+++ b/src/imdupes/utils/imutils.py
@@ -18,13 +18,13 @@ def hash_image(
         method: HashingMethod,
         hash_size: int = DEFAULT_HASH_SIZE
 ) -> str:
-    if method == HashingMethod.RGBA:
-        im = image if image.mode == 'RGBA' else image.convert('RGBA')
-        hash_value = imagehash.phash(im.getchannel('R'), hash_size=int(hash_size / 4)).__str__()
-        hash_value += imagehash.phash(im.getchannel('G'), hash_size=int(hash_size / 4)).__str__()
-        hash_value += imagehash.phash(im.getchannel('B'), hash_size=int(hash_size / 4)).__str__()
-        hash_value += imagehash.phash(im.getchannel('A'), hash_size=int(hash_size / 4)).__str__()
+    if method == HashingMethod.BW_HIST:
+        hash_value = imagehash.average_hash(image, hash_size=hash_size).__str__()
+        hash_value += average_histogram_hash(image).__str__()
         return hash_value
+
+    elif method == HashingMethod.BW:
+        return imagehash.average_hash(image, hash_size=hash_size).__str__()
 
     elif method == HashingMethod.RGB:
         im = image if image.mode == 'RGB' else image.convert('RGB')
@@ -33,12 +33,12 @@ def hash_image(
         hash_value += imagehash.phash(im.getchannel('B'), hash_size=int(hash_size / 3)).__str__()
         return hash_value
 
-    elif method == HashingMethod.BW:
-        return imagehash.average_hash(image, hash_size=hash_size).__str__()
-
-    elif method == HashingMethod.BW_HIST:
-        hash_value = imagehash.average_hash(image, hash_size=hash_size).__str__()
-        hash_value += average_histogram_hash(image).__str__()
+    elif method == HashingMethod.RGBA:
+        im = image if image.mode == 'RGBA' else image.convert('RGBA')
+        hash_value = imagehash.phash(im.getchannel('R'), hash_size=int(hash_size / 4)).__str__()
+        hash_value += imagehash.phash(im.getchannel('G'), hash_size=int(hash_size / 4)).__str__()
+        hash_value += imagehash.phash(im.getchannel('B'), hash_size=int(hash_size / 4)).__str__()
+        hash_value += imagehash.phash(im.getchannel('A'), hash_size=int(hash_size / 4)).__str__()
         return hash_value
 
     else:

--- a/src/imdupes/utils/imutils.py
+++ b/src/imdupes/utils/imutils.py
@@ -1,4 +1,6 @@
 import imagehash
+import numpy
+from imagehash import ImageHash, MeanFunc
 from PIL import Image
 
 from utils.globs import HashingMethod
@@ -18,25 +20,52 @@ def hash_image(
 ) -> str:
     if method == HashingMethod.RGBA:
         im = image if image.mode == 'RGBA' else image.convert('RGBA')
-
         hash_value = imagehash.phash(im.getchannel('R'), hash_size=int(hash_size / 4)).__str__()
         hash_value += imagehash.phash(im.getchannel('G'), hash_size=int(hash_size / 4)).__str__()
         hash_value += imagehash.phash(im.getchannel('B'), hash_size=int(hash_size / 4)).__str__()
         hash_value += imagehash.phash(im.getchannel('A'), hash_size=int(hash_size / 4)).__str__()
-
         return hash_value
 
     elif method == HashingMethod.RGB:
         im = image if image.mode == 'RGB' else image.convert('RGB')
-
         hash_value = imagehash.phash(im.getchannel('R'), hash_size=int(hash_size / 3)).__str__()
         hash_value += imagehash.phash(im.getchannel('G'), hash_size=int(hash_size / 3)).__str__()
         hash_value += imagehash.phash(im.getchannel('B'), hash_size=int(hash_size / 3)).__str__()
-
         return hash_value
 
     elif method == HashingMethod.BW:
         return imagehash.average_hash(image, hash_size=hash_size).__str__()
 
+    elif method == HashingMethod.BW_HIST:
+        hash_value = imagehash.average_hash(image, hash_size=hash_size).__str__()
+        hash_value += average_histogram_hash(image).__str__()
+        return hash_value
+
     else:
         raise ValueError(f'Unknown HashingMethod "{method.value}"')
+
+
+def average_histogram_hash(
+        image: Image,
+        mask: Image = None,
+        extrema: tuple[int, int] | tuple[float, float] = None,
+        mean: MeanFunc = numpy.mean
+) -> ImageHash:
+    """
+    Average Histogram computation using imagehash.Image.histogram().
+
+    A bilevel image (mode "1") is treated as a greyscale ("L") image by this function.
+
+    Takes the color histogram data, where for each data point, assign it a 1 or 0 based on if it is larger than the
+    global average or not. Then treats this stream of data as a string of bits to be converted to imagehash.ImageHash.
+
+    Takes all arguments available to imagehash.Image.histogram().
+
+    @image must be a PIL instance.
+    @mean how to determine the average luminescence. can try numpy.median instead.
+    """
+
+    hist = numpy.asarray(image.histogram(mask, extrema))
+    avg = mean(hist)
+    diff = hist > avg
+    return ImageHash(diff)

--- a/src/imdupes/utils/imutils.py
+++ b/src/imdupes/utils/imutils.py
@@ -26,7 +26,7 @@ def hash_image(
 
         return hash_value
 
-    if method == HashingMethod.RGB:
+    elif method == HashingMethod.RGB:
         im = image if image.mode == 'RGB' else image.convert('RGB')
 
         hash_value = imagehash.phash(im.getchannel('R'), hash_size=int(hash_size / 3)).__str__()
@@ -35,5 +35,8 @@ def hash_image(
 
         return hash_value
 
-    if method == HashingMethod.BW:
+    elif method == HashingMethod.BW:
         return imagehash.average_hash(image, hash_size=hash_size).__str__()
+
+    else:
+        raise ValueError(f'Unknown HashingMethod "{method.value}"')


### PR DESCRIPTION
- Grayscale hashing now uses [average hash](https://web.archive.org/web/20171112054354/https://www.safaribooksonline.com/blog/2013/11/26/image-hashing-with-python/) algorithm like it did in initial versions. This is to preserve legacy behaviors compatibility,
- Added a new more efficient color-sensitive hashing method: Grayscale Histogram Hashing (`grayscale-hist-hashing`): Takes the color histogram data of an image, where for each data point, assign it a 1 or 0 based on if it is larger than the global average or not. Then treats this stream of data as a string of bits to be converted to `imagehash.ImageHash`. This results in much lower running time comparing to `rgba-hashing` and `rgb-hashing`, while still having very high accuracy like its peers.